### PR TITLE
fix(presence): fix presence not synchronizing states properly

### DIFF
--- a/src/usePresence/usePresence.tsx
+++ b/src/usePresence/usePresence.tsx
@@ -17,14 +17,16 @@ export function usePresence<PayloadType, MetasType = Metas>(
       channel.on('presence_state', (newState) => {
         _setPresence((prevState) => {
           if (Object.keys(prevState).length === 0) return newState;
-          return Presence.syncState(prevState, newState);
+          const nextState = {...prevState};
+          return Presence.syncState(nextState, newState);
         });
       });
 
       channel.on('presence_diff', (newDiff) => {
         _setPresence((prevState) => {
-          if (Object.keys(prevState).length === 0) return prevState;
-          return Presence.syncDiff(prevState, newDiff);
+          // Note that prevState might be empty, we still need to sync it
+          const nextState = {...prevState};
+          return Presence.syncDiff(nextState, newDiff);
         });
       });
 


### PR DESCRIPTION
Presence state sync did not work properly because:

1. React was not picking up _presence changes because `Presence.sync*` methods expect mutable objects & return them as a result.
2. The if statement on `presence_diff` discarded a valid case when empty `prevState` should be synced to a `newDiff`